### PR TITLE
Include missing in exit code

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -70,7 +70,7 @@ fn read_path(path: &str) -> Result<PathBuf, String> {
 }
 
 /// Possible values for the --only flag.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum OnlyOpt {
     /// Failing tests.
     Fail,

--- a/src/executor/context.rs
+++ b/src/executor/context.rs
@@ -211,6 +211,11 @@ impl Context {
         st.print_summary().await?;
         println!();
 
-        Ok((st.timeout + st.fail) as i32)
+        match opts.post_filter {
+            Some(cli::OnlyOpt::Fail) => Ok((st.fail + st.timeout) as i32),
+            Some(cli::OnlyOpt::Missing) => Ok((st.miss) as i32),
+            Some(cli::OnlyOpt::Pass) => Ok(0),
+            None => Ok((st.fail + st.timeout + st.miss) as i32)
+        }
     }
 }


### PR DESCRIPTION
Closes #15 

I tested this manually on `cli-test`, but as far as I can tell, the output of cli-test is not checked automatically? Also, its version is `0.3.4` not `0.4.0`