### PR TITLE
Add --ignore-skip flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Runt Changelog
 ==============
 
+Unreleased
+-----
+- Add `--ignore-skip` to run tests with a `.skip` file
+
 0.4.0
 -----
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -33,6 +33,10 @@ pub struct Opts {
     #[argh(switch, short = 'v')]
     pub verbose: bool,
 
+    /// also run tests which are normally skipped with .skip files
+    #[argh(switch)]
+    pub ignore_skip: bool,
+
     /// filter out the reported test results based on test status
     /// ("pass", "fail", "miss") or a regex for the test file path.
     /// Applied after running the tests.

--- a/src/executor/context.rs
+++ b/src/executor/context.rs
@@ -22,8 +22,9 @@ impl Executor {
     /// completion)
     pub fn execute_all(
         self,
+        ignore_skip: bool,
     ) -> impl stream::Stream<Item = Result<results::Test, RuntError>> {
-        stream::iter(self.tests.into_iter().map(|test| test.execute_test()))
+        stream::iter(self.tests.into_iter().map(move |test| test.execute_test(ignore_skip)))
             .buffer_unordered(self.max_futures)
     }
 }
@@ -176,7 +177,7 @@ impl Context {
         opts: &cli::Opts,
     ) -> Result<i32, errors::RuntError> {
         let mut st = Status::new(self.exec.tests.len() as u64);
-        let mut tasks = self.exec.execute_all();
+        let mut tasks = self.exec.execute_all(opts.ignore_skip);
 
         // Initial summary printing to give user feedback that runt has started.
         st.stream_summary().await?;

--- a/src/executor/test.rs
+++ b/src/executor/test.rs
@@ -85,9 +85,9 @@ impl Test {
     /// std library fs::* and command::* so that there is a 1-to-1
     /// correspondence between tokio threads and spawned processes.
     /// This lets us control the number of parallel running processes.
-    pub async fn execute_test(self) -> Result<results::Test, RuntError> {
+    pub async fn execute_test(self, ignore_skip: bool) -> Result<results::Test, RuntError> {
         let skip_path = self.skip_file();
-        if skip_path.exists() {
+        if skip_path.exists() && !ignore_skip {
             return Ok(results::Test {
                 path: self.path,
                 expect_path: skip_path,


### PR DESCRIPTION
I have some long running tests which download files. I want to test them in CI but don't feel like remembering to add the `-e` flag every time I run runt

My initial idea was to add a `exclude_by_default` toml flag which would only run the tests if -i was used, but then you need to -i *all* tests which is also not what I want

This skip solution works for my use though it does feel like a bit of a hack